### PR TITLE
clarify copying step in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![CircleCI](https://circleci.com/gh/bu-ist/sample-plugin.svg?style=shield)](https://circleci.com/gh/bu-ist/sample-plugin)
 ## Running Tests
 1. Download https://github.com/bu-ist/sample-plugin/archive/master.zip
-2. Copy everything but README & sample-plugin.php into your plugin/theme.
+2. Copy everything (don't forget about hidden dot files like .travis.yml) into your plugin/theme except the following:  `README.md`, `sample-plugin.php`, `.git`, `.gitignore`.
 3. Update settings in the `tests/bootstrap.php` file to reflect your plugin/theme.
 4. Write tests.
 5. If this is not the first run,cleanup from the files and database from prior runs:


### PR DESCRIPTION
If finder is not set up to display dot hidden files, then those dot files are ignored when copying over the contents of the zip folder. I've tried to improve the instructions in the README file to remind us to copy those dot files as well.

@DannyCrews since you ran into this issue as well, let me know if you think I've worded this properly.