### PR TITLE
Add .codeclimate.yml for running locally

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,47 @@
+---
+version: 2
+prepare:
+  fetch:
+    - "https://raw.githubusercontent.com/bu-ist/coding-standards/master/code-climate-rule-sets/.mdlrc"
+    - "https://raw.githubusercontent.com/bu-ist/coding-standards/master/code-climate-rule-sets/markdown.rb"
+    - url: "https://raw.githubusercontent.com/bu-ist/coding-standards/master/code-climate-rule-sets/phpcs-plugins.xml"
+      path: "phpcs.xml"
+plugins:
+  csslint:
+    enabled: false
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - javascript
+        - php
+  eslint:
+    enabled: false
+    channel: eslint-3
+  fixme:
+    enabled: true
+  markdownlint:
+    enabled: true
+  phpcodesniffer:
+    enabled: true
+    config:
+      file_extensions: php
+      standard: phpcs.xml.dist
+      ignore_warnings: false
+      encoding: utf-8
+  phpmd:
+    enabled: true
+    config:
+      file_extensions: php
+      rulesets: codesize,naming,unusedcode
+  scss-lint:
+    enabled: false
+exclude_patterns:
+  - bower_components/
+  - languages/
+  - node_modules/
+  - .sass-cache/
+  - tests/
+  - "*.min.css"
+  - "*.min.js"
+  - "**.css"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ node_modules/
 *.sql
 *.tar.gz
 *.zip
+
+# Ignore files downloaded from codeclimate prepare fetch key, defined in .codeclimate.yml
+markdown.rb
+.mdlrc

--- a/README.md
+++ b/README.md
@@ -40,11 +40,22 @@ sudo ln -s /tmp/mysql.sock /var/mysql/mysql.sock
 
 ## Running Code Climate locally
 
+### Prerequisites
+
+Install the prerequisites listed on the [Code Climate repo](https://github.com/codeclimate/codeclimate/#prerequisites).
+
+- [Docker](https://www.docker.com/), or use [Docker for Mac](https://docs.docker.com/docker-for-mac/) for macOS.
+- [Homebrew](https://brew.sh/) (only if on macOS)
+
+### Installation
+
 To run Code Climate reports locally, it must be installed on your machine.
 Directions to install locally are on the Code Climate GitHub repository
 https://github.com/codeclimate/codeclimate/.
 
-The easiest way to install the `codeclimate` command is with the homebrew
+
+#### For macOS
+The easiest way to install the `codeclimate` command on macOS is with the homebrew
 package manager. [Install homebrew before continuing](https://brew.sh/).
 Otherwise, continue on to the next step.
 
@@ -53,14 +64,20 @@ In a Terminal session, run the following commands:
 1. `brew tap codeclimate/formulae`
 1. `brew install codeclimate`
 
+#### Alternative Approach
+
+If on Windows or another operating system, run the following commands:
+
+1. `curl -L https://github.com/codeclimate/codeclimate/archive/master.tar.gz | tar xvz`
+1. `cd codeclimate-* && sudo make install`
+
+### Example commands
+
 Now you should have the `codeclimate` command available. Test it by running
 `codeclimate version`.
 
 A list of commands is available on the [Code Climate GitHub page](https://github.com/codeclimate/codeclimate/#commands).
-
-### Example commands
-
-The following commands can be run in the root of your repository:
+The following commands can be run in the root of your repository:o
 
 #### Analyze the entire repo
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ docker run \
 But since that's a burden to type each time, it is preferred to use Code
 Climate's wrapper scripts.
 
+#### Install script for macOS using Homebrew
 
-#### Installing wrapper script For macOS using Homebrew
 The easiest way to install the `codeclimate` command on macOS is with the homebrew
 package manager. [Install homebrew before continuing](https://brew.sh/).
 Otherwise, continue on to the next step.
@@ -93,7 +93,7 @@ In a Terminal session, run the following commands:
 1. `brew tap codeclimate/formulae`
 1. `brew install codeclimate`
 
-#### Installing wrapper script for any operating system (Windows, Linux, etc)
+#### Install script for any os (Windows, Linux, etc)
 
 If on Windows or another operating system, run the following commands:
 

--- a/README.md
+++ b/README.md
@@ -42,20 +42,24 @@ sudo ln -s /tmp/mysql.sock /var/mysql/mysql.sock
 
 ### Prerequisites
 
-Install the prerequisites listed on the [Code Climate repo](https://github.com/codeclimate/codeclimate/#prerequisites).
+To run code climate locally, grab an existing plugin or theme's .codeclimate.yml file:
+
+- For plugins, use the one from the [sample plugin repo](https://github.com/bu-ist/sample-plugin/blob/master/.codeclimate.yml).
+- For themes, use the one from the [responsive framework's child-starter](https://github.com/bu-ist/responsive-child-starter/blob/develop/.codeclimate.yml).
+
+Next, follow the instructions listed on the [Code Climate repo](https://github.com/codeclimate/codeclimate/#prerequisites), or continue by installing the prerequisites that are listed:
 
 - [Docker](https://www.docker.com/), or use [Docker for Mac](https://docs.docker.com/docker-for-mac/) for macOS.
 - [Homebrew](https://brew.sh/) (only if on macOS)
 
 ### Installation
 
-To run Code Climate reports locally, it must be installed on your machine.
-Directions to install locally are on the Code Climate GitHub repository
-https://github.com/codeclimate/codeclimate/.
+_Note: All of this information is available on the [Code Climate repo](https://github.com/codeclimate/codeclimate/). To continue, make sure you have [Docker](https://www.docker.com/), or [Docker for Mac](https://docs.docker.com/docker-for-mac/) for macOS._
 
-_Note: Make sure you have [Docker](https://www.docker.com/), or use [Docker for Mac](https://docs.docker.com/docker-for-mac/) for macOS._
+To run Code Climate reports locally, the Docker image must be installed on your machine.
 
-Run the following command in a Terminal session:
+Run the following command in a Terminal session to pull down the Docker image:
+
 ```
 docker pull codeclimate/codeclimate
 ```
@@ -73,10 +77,10 @@ docker run \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume /tmp/cc:/tmp/cc \
   codeclimate/codeclimate help
-  ```
+```
 
-  But since that's a burden to type each time, it is preferred to use Code
-  Climate's wrapper scripts.
+But since that's a burden to type each time, it is preferred to use Code
+Climate's wrapper scripts.
 
 
 #### Installing wrapper script For macOS using Homebrew

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Now you should have the `codeclimate` command available. Test it by running
 `codeclimate version`.
 
 A list of commands is available on the [Code Climate GitHub page](https://github.com/codeclimate/codeclimate/#commands).
-The following commands can be run in the root of your repository:o
+The following commands can be run in the root of your repository:
 
 #### Analyze the entire repo
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,33 @@ To run Code Climate reports locally, it must be installed on your machine.
 Directions to install locally are on the Code Climate GitHub repository
 https://github.com/codeclimate/codeclimate/.
 
+_Note: Make sure you have [Docker](https://www.docker.com/), or use [Docker for Mac](https://docs.docker.com/docker-for-mac/) for macOS._
 
-#### For macOS
+Run the following command in a Terminal session:
+```
+docker pull codeclimate/codeclimate
+```
+
+This will download the Docker image that code climate will use to run its
+analysis tools.
+
+After that finishes, code climate can now be run using the following example
+command:
+```
+docker run \
+  --interactive --tty --rm \
+  --env CODECLIMATE_CODE="$PWD" \
+  --volume "$PWD":/code \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  --volume /tmp/cc:/tmp/cc \
+  codeclimate/codeclimate help
+  ```
+
+  But since that's a burden to type each time, it is preferred to use Code
+  Climate's wrapper scripts.
+
+
+#### Installing wrapper script For macOS using Homebrew
 The easiest way to install the `codeclimate` command on macOS is with the homebrew
 package manager. [Install homebrew before continuing](https://brew.sh/).
 Otherwise, continue on to the next step.
@@ -64,7 +89,7 @@ In a Terminal session, run the following commands:
 1. `brew tap codeclimate/formulae`
 1. `brew install codeclimate`
 
-#### Alternative Approach
+#### Installing wrapper script for any operating system (Windows, Linux, etc)
 
 If on Windows or another operating system, run the following commands:
 
@@ -73,8 +98,8 @@ If on Windows or another operating system, run the following commands:
 
 ### Example commands
 
-Now you should have the `codeclimate` command available. Test it by running
-`codeclimate version`.
+If using the wrapper scripts, the `codeclimate` command should be available.
+Test it by running `codeclimate version`.
 
 A list of commands is available on the [Code Climate GitHub page](https://github.com/codeclimate/codeclimate/#commands).
 The following commands can be run in the root of your repository:

--- a/README.md
+++ b/README.md
@@ -37,3 +37,45 @@ One potential fix for this specific scenario is to symlink the php default socke
 ```
 sudo ln -s /tmp/mysql.sock /var/mysql/mysql.sock
 ```
+
+## Running Code Climate locally
+
+To run Code Climate reports locally, it must be installed on your machine.
+Directions to install locally are on the Code Climate GitHub repository
+https://github.com/codeclimate/codeclimate/.
+
+The easiest way to install the `codeclimate` command is with the homebrew
+package manager. [Install homebrew before continuing](https://brew.sh/).
+Otherwise, continue on to the next step.
+
+In a Terminal session, run the following commands:
+
+1. `brew tap codeclimate/formulae`
+1. `brew install codeclimate`
+
+Now you should have the `codeclimate` command available. Test it by running
+`codeclimate version`.
+
+A list of commands is available on the [Code Climate GitHub page](https://github.com/codeclimate/codeclimate/#commands).
+
+### Example commands
+
+The following commands can be run in the root of your repository:
+
+#### Analyze the entire repo
+
+```
+codeclimate analyze
+```
+
+#### Analyze just one file
+
+```
+codeclimate analyze includes/functions.php
+```
+
+#### Validate the contents of your codeclimate file
+
+```
+codeclimate validate-config
+```


### PR DESCRIPTION
## Summary

This PR adds the `.codeclimate.yml` file which will serve two purposes:

1. It will be used instead of the In-App configuration added to the site; so GitHub will now use this file for analyzing code.
2. It will also be used for running codeclimate locally, so errors can fixed before pushing up to GitHub.

This file was initially taken from bu-banners/.codeclimate.yml.

Then edits were made after installing codeclimate on my machine and then running commands like `codeclimate validate-config` which noted to change `exclude_paths` to `exclude_patterns`, add a `version` key, etc.

Then the key under plugins > phpcodesniffer > config > standard needed to be changed from `phpcs.xml` to `phpcs.xml.dist` so it doesn’t error on phpcs engine.

This PR also adds files to .gitignore that are fetched in .codeclimate.yml's prepare > fetch key. These files aren't going to be modified so they should be ignored.

Instructions also exist in the README.

## Instructions for testing running codeclimate locally

It is easiest to install codeclimate on your machine via homebrew. http://brew.sh . Once homebrew is installed, follow the steps outlined on the GitHub website for codeclimate https://github.com/codeclimate/codeclimate/:

1. run `brew tap codeclimate/formulae`
2. run `brew install codeclimate`

Now the codeclimate command should be available for use in the root of the repo. Can be tested by checking out this branch and running something like `codeclimate analyze includes/publications.php` for a specific file or just `codeclimate analyze` for a complete repo analysis. Note the commands should be run from the root of the repo where the `.codeclimate.yml` file exists.